### PR TITLE
Allow LTP (Linux Test Project) to build

### DIFF
--- a/package/libtirpc/0008-include-stdint.h-for-uintptr_t.patch
+++ b/package/libtirpc/0008-include-stdint.h-for-uintptr_t.patch
@@ -1,0 +1,31 @@
+From 18f8a605e176f0362da22fd1203eb7cedb136aaf Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 20 Jun 2017 22:06:35 +0200
+Subject: [PATCH] include stdint.h for uintptr_t
+
+Fixes
+| ../../libtirpc-1.0.1/src/xdr_sizeof.c:93:13: error: 'uintptr_t' undeclared (first use in this function); did you mean '__intptr_t'?
+|   if (len < (uintptr_t)xdrs->x_base) {
+|              ^~~~~~~~~
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Dmitrii Kolesnichenko <dmitrii@synopsys.com>
+---
+ src/xdr_sizeof.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/xdr_sizeof.c b/src/xdr_sizeof.c
+index d23fbd1..79d6707 100644
+--- a/src/xdr_sizeof.c
++++ b/src/xdr_sizeof.c
+@@ -39,6 +39,7 @@
+ #include <rpc/xdr.h>
+ #include <sys/types.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ #include "un-namespace.h"
+ 
+ /* ARGSUSED */
+-- 
+2.9.4
+

--- a/package/ltp-testsuite/0005-trace_sched-wexitstatus.patch
+++ b/package/ltp-testsuite/0005-trace_sched-wexitstatus.patch
@@ -1,0 +1,34 @@
+commit 34f0c83dc026f5403fd0e408a31efc56208bd47b
+Author: Khem Raj <raj.khem@gmail.com>
+Date:   Thu Jul 21 21:26:45 2016 -0700
+
+    trace_shed: Drop useless and wrong WEXITSTATUS(status)
+    
+    The thread return status is either -1 or pointer to the table. So there
+    is no point in passing it to WEXITSTATUS() and priting the value.
+    
+    The code started to fail to compile after glibc commit:
+    https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=b49ab5f4503f36dcbf43f821f817da66b2931fe6;hp=5f5682b9654101ccaf375c2814cbddbe6033a725
+    
+    trace_sched.c:425:16: error: invalid operands to binary & (have
+    'thread_sched_t * {aka struct <anonymous> *}' and 'int')
+          thrd_ndx, WEXITSTATUS(status));
+    
+    Signed-off-by: Khem Raj <raj.khem@gmail.com>
+    Acked-by: Cyril Hrubis <chrubis@suse.cz>
+
+diff --git a/testcases/kernel/sched/tool/trace_sched.c b/testcases/kernel/sched/tool/trace_sched.c
+index 781568613138..71caf239a825 100644
+--- a/testcases/kernel/sched/tool/trace_sched.c
++++ b/testcases/kernel/sched/tool/trace_sched.c
+@@ -421,8 +421,8 @@ int main(int argc,		/* number of input parameters.                        */
+ 		} else {
+ 			if (status == (thread_sched_t *) - 1) {
+ 				fprintf(stderr,
+-					"thread [%d] - process exited with errors %d\n",
+-					thrd_ndx, WEXITSTATUS(status));
++					"thread [%d] - process exited with exit code -1\n",
++					thrd_ndx);
+ 				exit(-1);
+ 			} else {
+ 				exp_prio[thrd_ndx] = status->exp_prio;


### PR DESCRIPTION
These two patches (one from buildroot, the other from LTP directly) allow LTP to build.