### PR TITLE
use automake 1.15.1 for Perl 5.26 regex compat

### DIFF
--- a/package/automake/automake.hash
+++ b/package/automake/automake.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256  9908c75aabd49d13661d6dcb1bc382252d22cc77bf733a2d55e87f2aa2db8636  automake-1.15.tar.xz
+sha256  af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf  automake-1.15.1.tar.xz

--- a/package/automake/automake.mk
+++ b/package/automake/automake.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-AUTOMAKE_VERSION = 1.15
+AUTOMAKE_VERSION = 1.15.1
 AUTOMAKE_SOURCE = automake-$(AUTOMAKE_VERSION).tar.xz
 AUTOMAKE_SITE = $(BR2_GNU_MIRROR)/automake
 AUTOMAKE_LICENSE = GPL-2.0+


### PR DESCRIPTION
Perl 5.26 breaks on substitute_ac_subst_variables regex - fixed upstream